### PR TITLE
minor corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,10 @@ import { AmexioWidgetModule,CommonDataService } from 'amexio-ng-extensions';
 import { AmexioChartsModule } from 'amexio-ng-extensions';
 
 //To import Maps 
-import { AmexioMapsModule } from 'amexio-ng-extensions';
+import { AmexioMapModule } from 'amexio-ng-extensions';
 
 // To import Dashboard
-import { AmexioDashboardModule } from 'amexio-ng-extensions';
+import { AmexioDashBoardModule } from 'amexio-ng-extensions';
 
 
 // To import Enterprise
@@ -285,8 +285,8 @@ import { AmexioEnterpriseModule } from 'amexio-ng-extensions';
     FormsModule,
     AmexioWidgetModule,
     AmexioChartsModule,
-    AmexioMapsModule,
-    AmexioDashboardModule,
+    AmexioMapModule,
+    AmexioDashBoardModule,
     AmexioEnterpriseModule
   ],
   providers: [CommonDataService],
@@ -329,7 +329,7 @@ export class AppModule { }
 </tr>
 
 <tr>
-<td>AmexioMapsModule</td>
+<td>AmexioMapModule</td>
 </tr>
 
 <tr>
@@ -348,10 +348,38 @@ export class AppModule { }
 
 # Amexio Themes (Amexio / Amexio Material)
 
-To use the default theme import the
-`../node_modules/amexio-ng-extensions/styles/mda/at-md-blue.scss`
-in your app styles.scss
-Or refer the below table for other themes provided.
+To use the default theme, add
+`node_modules/amexio-ng-extensions/styles/mda/at-md-blue.scss`
+in your application's **angular.json** file:
+```
+{
+  "projects": {
+    "spa": {
+      "architect": {
+        "build": {
+          "options": {
+            "styles": {
+              [
+                "src/styles.scss",
+                "node_modules/amexio-ng-extensions/styles/mda/at-md-blue.scss"
+              ]
+            }
+          }
+        },
+        "test": {
+          "options": {
+            "styles": [
+              "src/styles.scss",
+              "node_modules/amexio-ng-extensions/styles/mda/at-md-blue.scss"
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+Refer the below table for other themes provided.
 
 <table> 
 <tr>


### PR DESCRIPTION
1. fix typos in module names
2. fix compilation errors when importing theme into styles.scss:
`@import "../../node_modules/amexio-ng-extensions/styles/mda/at-md-blue.scss";`
- will cause the following compilation errors: 
o	cannot resolve ‘prev.png’, ‘next.png’, & ‘search-icon.png’
this happens when importing theme in both:
	src/styles.scss
	src/content/styles.scss

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1. build compilation errors due to typos in module names

Issue Number: N/A


## What is the new behavior?

eliminates compilation errors

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

